### PR TITLE
ScalaTest in Docker at Travis CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# scala
+project/project/
+project/target/
+target/*
+*.class
+
+# intelij
+.idea/*
+
+*.iml
+*.ipr
+*.iws
+.idea
+out
+
+# vim
+.*.swp
+.*.swo
+*~
+
+# mac
+.DS_Store
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+
+language: scala
+
+notifications:
+  slack:
+    secure: VTtxrPU01wm0Kwdpb1RnA9tMQbjdO2/y0W1y/zqwOOrlzcvNjA/EnItF/gZIKktsraShb1+0nzVesWAU+5xAdLEKOJNCo7ipaooBbdFTGv8CnPxP4X3LDnQ86ReMfmbZLBpe86fm3ZTKC5PWKwoYKKfpSqqTXLHt0HUl3HX2lN+2M7minku+pTIk5OEyVTMSsqignJea3SvhS9Uk9L0qwhKa/TFZQnKW11van4QMOejZ1cxVrsTLcqK4s6J61CWc3l3PxSHdmDFwBA2bsy1SAlOTlBKrOfRwtdRkUfxAQdXFybJLzawkgphpDz2+MJnDYQtoy3xeflsjQYW8ST7X/ucIujP4rlsJoS03CdS2UeFX1CD1ZhR/2tR+CV2d+bY8Kol6tzCeeu3Fd+eKaCOfLWk6SRBpQ3kNtzlB3LE0LkrGG2iozV6tTS5S3cvg2+8QlNJ93/anxj+6PsYcjuJUBBBXhunKfuaL3Z35ewLTEleHUt0Kjx5KYc5V3tQXdYAsFsxKNPIqK8rgR3lsjU6J5AfZmQO7MVz5w5ts4vFfZOJ23ZIBoJwuwdgpSxWanPo+z0gZfcop4XRbU41DgfomDQxNzWOG6sIFUUE4dlx7U36S+uEdCf3AJ+6AZHAPd+6QqWwOuoOticoTv0HHXLHyGBCZLShI7xVZ7I9ceojUgTY=
+
+# These directories are cached to S3 at the end of the build.
+cache:
+  directories:
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt/boot/
+
+services:
+- docker
+
+before_install:
+- make docker
+
+script:
+- make docker-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM agapito/centos7-scala:latest
+
+WORKDIR /root
+
+# install deps and create testdir
+RUN yum -y install make && \
+    mkdir -p /root/buildtools-test
+
+WORKDIR /root/buildtools-test
+
+COPY build.sbt /root/buildtools-test
+COPY src /root/buildtools-test/src
+COPY project /root/buildtools-test/project
+
+# run tests
+CMD ["sbt", "test"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+DOCKER=docker
+BUILDNAME=rocket/testbp
+PROJECT=travis-docker-tests
+
+.DEFAULT_GOAL=help
+
+.PHONY: help
+
+help:
+	@echo "------------------------------------------------------------------------"
+	@echo "$(PROJECT)"
+	@echo "------------------------------------------------------------------------"
+	@grep -E '^[a-zA-Z_/%\-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+docker: Dockerfile ## Build the docker image
+	$(DOCKER) build -t $(BUILDNAME) .
+
+docker-test: docker ## Run tests inside the container
+	$(DOCKER) run -v $(HOME)/.ivy2:/root/.ivy2 -v $(HOME)/.sbt:/root/.sbt -it $(BUILDNAME) bash -c "sbt test"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # buildtools-test
+
+[![Build Status](https://travis-ci.org/ProjectRocket/buildtools-test.svg?branch=master)](https://travis-ci.org/ProjectRocket/buildtools-test)
+
+Simple boilerplate Scala project using ScalaTest. Tests performed within a Docker image at Travis CI, taking advantage of Travis' cache to avoid downloading the dependencies on every build.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,16 @@
+name := "testbp"
+
+version := "1.0"
+
+scalaVersion := "2.11.8"
+
+// https://mvnrepository.com/artifact/org.scalatest/scalatest_2.11
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.1"
+
+// Create assembly jar containing test classes
+/**********************************************
+Project.inConfig(Test)(baseAssemblySettings)
+assemblyJarName in (Test, assembly) := s"${name.value}-assemblytest-${version.value}.jar"
+
+test in (Test, assembly) := {} // disable tests in assembly
+**********************************************/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+logLevel := Level.Warn
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+

--- a/src/main/scala-2.11/org/rocket/testbp/Main.scala
+++ b/src/main/scala-2.11/org/rocket/testbp/Main.scala
@@ -1,0 +1,14 @@
+package org.rocket.testbp
+
+/**
+  * Created by agapito on 17/01/2017.
+  */
+object Main extends App {
+  val hi = new Hi("world")
+  println(hi.sayHello)
+}
+
+class Hi(name:String) {
+  def sayHello: String = s"Hello $name!"
+}
+

--- a/src/test/scala-2.11/org/rocket/testbp/HiTest.scala
+++ b/src/test/scala-2.11/org/rocket/testbp/HiTest.scala
@@ -1,0 +1,13 @@
+package org.rocket.testbp
+
+import org.scalatest.FunSuite
+
+/**
+  * Created by agapito on 18/01/2017.
+  */
+class HiTest extends FunSuite {
+  test("Well behaved programs should know how to greet people.") {
+    val hi = new Hi("tester")
+    assert(hi.sayHello == "Hello tester!")
+  }
+}


### PR DESCRIPTION
This is a simple Hello World with respective test.

Issuing 'make docker' will build a Centos 7 Docker image with
git, scala, and sbt, which will be used for testing.

To run the tests within the Docker image type 'make docker-test'
after building the image.

This is used to run tests at Travis. Here we are taking advantage of
Travis' cache, so that dependencies are only downloaded once. Because
the environment variable $HOME is used in the Makefile this works both
on Travis and on your computer.